### PR TITLE
feat: Web UI のノードやボタンの遷移先を調整できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,22 @@ go install github.com/mazrean/isucrud@latest
 Usage of isucrud:
   -web
       run as web server
-  -addr
+  -addr string
       web server address (default ":7070")
+  -base string
+      base for serving the web server (default "/")
   -dst string
-    	destination file (default "./dbdoc.md")
+      destination file (default "./dbdoc.md")
   -ignore value
-    	ignore function
+      ignore function
   -ignoreInitialize
-    	ignore functions with 'initialize' in the name (default true)
+      ignore functions with 'initialize' in the name (default true)
   -ignoreMain
-    	ignore main function (default true)
+      ignore main function (default true)
   -ignorePrefix value
-    	ignore function
+      ignore function
   -version
-    	show version
+      show version
 ```
 
 ## 注意事項

--- a/internal/ui/asset/template.html
+++ b/internal/ui/asset/template.html
@@ -18,7 +18,7 @@
 </head>
 
 <body>
-  {{if .IsFiltered}}<button onclick="location.href = '/'">全ノードを表示する</button>{{end}}
+  {{if .IsFiltered}}<button onclick="location.href = {{.BasePath}}">全ノードを表示する</button>{{end}}
   <div>
     nodes: 
     {{range .NodeTypes}}<span>

--- a/internal/ui/mermaid.go
+++ b/internal/ui/mermaid.go
@@ -33,6 +33,11 @@ type EdgeType struct {
 	valid bool
 }
 
+type RenderMermaidOption struct {
+	IsHttp   bool
+	BasePath string
+}
+
 var (
 	nodeTypes = []NodeType{
 		dbdoc.NodeTypeTable:    {"table", "テーブル", tableNodeColor, true},
@@ -50,7 +55,7 @@ var (
 func RenderMermaid(
 	w io.StringWriter,
 	nodes []*dbdoc.Node,
-	isHttp bool,
+	option RenderMermaidOption,
 ) error {
 	_, err := w.WriteString("graph LR\n")
 	if err != nil {
@@ -108,9 +113,9 @@ func RenderMermaid(
 		}
 	}
 
-	if isHttp {
+	if option.IsHttp {
 		for _, node := range nodes {
-			_, err = w.WriteString(fmt.Sprintf("  click %s \"/?node=%s\"\n", node.ID, node.ID))
+			_, err = w.WriteString(fmt.Sprintf("  click %s \"%s?node=%s\"\n", node.ID, option.BasePath, node.ID))
 			if err != nil {
 				return fmt.Errorf("failed to write click event: %w", err)
 			}

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -22,6 +22,7 @@ var (
 
 type TemplateParam struct {
 	IsFiltered  bool
+	BasePath    string
 	NodeTypes   []NodeType
 	EdgeTypes   []EdgeType
 	Nodes       []*dbdoc.Node
@@ -39,7 +40,9 @@ func RenderMarkdown(dest string, nodes []*dbdoc.Node) error {
 	err = RenderMermaid(
 		sb,
 		nodes,
-		false,
+		RenderMermaidOption{
+			IsHttp: false,
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to write mermaid: %w", err)
@@ -64,7 +67,7 @@ func RenderMarkdown(dest string, nodes []*dbdoc.Node) error {
 	return nil
 }
 
-func RenderHTML(w io.Writer, nodes []*dbdoc.Node, targetNodeID string) error {
+func RenderHTML(w io.Writer, nodes []*dbdoc.Node, targetNodeID string, basePath string) error {
 	filtered := false
 	filteredNodes := nodes
 	if targetNodeID != "" {
@@ -76,7 +79,10 @@ func RenderHTML(w io.Writer, nodes []*dbdoc.Node, targetNodeID string) error {
 	err := RenderMermaid(
 		sb,
 		filteredNodes,
-		true,
+		RenderMermaidOption{
+			IsHttp:   true,
+			BasePath: basePath,
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to write mermaid: %w", err)
@@ -89,6 +95,7 @@ func RenderHTML(w io.Writer, nodes []*dbdoc.Node, targetNodeID string) error {
 
 	err = tmpl.Execute(w, TemplateParam{
 		IsFiltered:  filtered,
+		BasePath:    basePath,
 		NodeTypes:   nodeTypes[1:],
 		EdgeTypes:   edgeTypes[1:],
 		Nodes:       nodes,

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	ignoreMain, ignoreInitialize bool
 	web                          bool
 	addr                         string
+	base                         string
 )
 
 func init() {
@@ -34,6 +35,7 @@ func init() {
 	flag.BoolVar(&ignoreInitialize, "ignoreInitialize", true, "ignore functions with 'initialize' in the name")
 	flag.BoolVar(&web, "web", false, "run as web server")
 	flag.StringVar(&addr, "addr", "localhost:7070", "address to listen on")
+	flag.StringVar(&base, "base", "/", "base for serving the web server")
 }
 
 func main() {
@@ -69,7 +71,7 @@ func main() {
 
 			targetNodeID := r.URL.Query().Get("node")
 
-			err := ui.RenderHTML(w, nodes, targetNodeID)
+			err := ui.RenderHTML(w, nodes, targetNodeID, base)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}


### PR DESCRIPTION
ISUCONお疲れ様でした。素晴らしいツールをありがとうございます。
使ってみて一点不便なことがあったので、PRを作成しました。

Web UI をリバースプロキシの後ろに置くと、ノードをクリックしたときの遷移がうまくいきません。
以下は Caddyfile の例です。`localhost:8080/isucrud` で Mermaid を見ることはできますが、クリックの遷移先が `localhost:8080/?node=` になります。
```
# Example Caddyfile
:8080

handle /isucrud {
    reverse_proxy :7070
}
```

上記の問題を解消するため、遷移先の base path を指定するオプションを追加しました。
```
isucrud -web -base /isucrud ./...
```
動作確認:

https://github.com/user-attachments/assets/51a86e01-2b74-49b5-bcad-3b2307ce5d23

